### PR TITLE
Update index1.js

### DIFF
--- a/kadai03/index1.js
+++ b/kadai03/index1.js
@@ -1,8 +1,15 @@
 const n = parseInt(process.argv[2])
-for (let m =2;m<=n;m=m+1){
+
+let isPrime = true
+
+for (let m =2;m<=n-1;m=m+1){
     if(n%m===0){
+        isPrime = false
         console.log('素数ではない')
         break
     }
+}
 
+if(isPrime) {
+  console.log(n)
 }


### PR DESCRIPTION
`m = n` の時までループが回ってしまうので、それ自身の数で割ってしまい、全ての数が「素数でない」と表示されてしまいます。
「エラストテネスのふるい」で調べてみてください。